### PR TITLE
Remove mention of preprint server and fix Living into Perpetual

### DIFF
--- a/website_text/for_authors.md
+++ b/website_text/for_authors.md
@@ -9,7 +9,6 @@ The contents of the  letter are described in the [Guide for writing articles for
 Once approved for submission, the authors should prepare the manuscript using [LaTeX](https://www.latex-project.org/) in a suitable public [GitHub](http://wwww.github.com) repository, using our [LaTeX template](https://github.com/livecomsjournal/article_templates). 
 Instructions on how to use the templates can be found [in the GitHub repository with the template files](http://https://github.com/livecomsjournal/article_templates).
 
-Formal submission of the manuscript occurs only when the authors post the resulting document to a preprint server of their choice and also offically submit the linked manuscript to LiveCoMS. 
 A complete description of the submission process can be found in [the guide for writing an article for LiveCoMS](https://livecomsjournal.github.io/).
 
 # Review and revision


### PR DESCRIPTION
Remove outdated mention of preprint server on website.