### PR TITLE
Remove reference to living reviews

### DIFF
--- a/website_text/about.md
+++ b/website_text/about.md
@@ -1,3 +1,3 @@
 The Living Journal of Computational Molecular Science (LiveCoMS) provides a peer-reviewed home for manuscripts which share best practices in molecular modeling and simulation. 
-These works are living documents, regularly updated with community input, and can include living or perpetual reviews, tutorials, comparisons between software packages, and other documents which aim to improve the studies in the field and require ongoing updates.
+These works are living documents, regularly updated with community input, and can include perpetually updated reviews, tutorials, comparisons between software packages, and other documents which aim to improve the studies in the field and require ongoing updates.
 


### PR DESCRIPTION
I think David meant to do this in the last PR, but it didn't actually get in.