### PR TITLE
Removing student editors, giving credit elsewhere

### DIFF
--- a/website_text/editorial_board.md
+++ b/website_text/editorial_board.md
@@ -37,8 +37,3 @@
 
 - [Daniel M. Zuckerman](http://www.ohsuwelcome.com/xd/education/schools/school-of-medicine/departments/basic-science-departments/biomedical-engineering/bme-labs/zuckerman-lab/index.cfm) (Oregon Health & Science University)
 
-## Student Editors
-
-- Justin Gilmer (Vanderbilt University)
-
-- Pascal Merz (University of Colorado Boulder)


### PR DESCRIPTION
Removing listing of student editors, as we are eliminating the position.  Specifically add credits to those people on the GitHub Pages repo in a PR later today.