### PR TITLE
Highlight article types, our key strength

### DIFF
--- a/website_text/about.md
+++ b/website_text/about.md
@@ -1,8 +1,15 @@
-The [Living Journal of Computational Molecular Science](http://livecomsjournal.org) (LiveCoMS) provides a peer-reviewed home for manuscripts which share best practices in molecular modeling and simulation.
-These works are living documents, [regularly updated on GitHub with community input](https://livecomsjournal.github.io/about/paper_code/), and can include perpetually updated reviews, tutorials, comparisons between software packages, and other documents which aim to improve the studies in the field and require ongoing updates.
+The [Living Journal of Computational Molecular Science](http://livecomsjournal.org) (LiveCoMS) provides a low-cost, peer-reviewed home for manuscripts which will document and strengthen community standards in molecular modeling and simulation.
+LiveCoMS is a non-profit journal run by and for members of the molecular simulation community.
+Currently, five categories of articles are being solicited:
+- [Best Practices](https://livecomsjournal.github.io/authors/best_practices/)
+- [Reviews](https://livecomsjournal.github.io/authors/perpetual_reviews/)
+- [Tutorials](https://livecomsjournal.github.io/authors/tutorials/)
+- [Comparisons between software packages](https://livecomsjournal.github.io/authors/compare_simulations/)
+- [Lessons learned](https://livecomsjournal.github.io/authors/lessons_learned/)
+All these works are expected to be living documents, [regularly updated on GitHub with community input](https://livecomsjournal.github.io/about/paper_code/).
 
 For more on LiveCoMS, be sure to read our vision document on [Why we need the Living Journal of Computational Molecular Science](http://www.livecomsjournal.org/article/2031-why-we-need-the-living-journal-of-computational-molecular-science).
 
-If you are interested in submitting, author instructions and editorial policies are available on our instructional pages at [https://livecomsjournal.github.io](https://livecomsjournal.github.io), and submission is via the [journal website](http://livecomsjournal.org).
+If you are interested in submitting, please see [author instructions](https://livecomsjournal.github.io/authors/) and [editorial policies](https://livecomsjournal.github.io/policies/).  Submission is via the [journal website](http://livecomsjournal.org).
 
 Cover art: Merry Wang


### PR DESCRIPTION
I also made links more specific.  I suggesting merging content from semi-duplicate About page now on github.io ... unfortunately I couldn't easily see how to get to the raw md text to copy it over.