### PR TITLE
move reviewer letter templates here

### DIFF
--- a/website_text/letter_templates.md
+++ b/website_text/letter_templates.md
@@ -1,0 +1,88 @@
+Below of typical form letters used for correspondence with reviewers.  Note that the official form letters are saved as templates on the Scholastica site.  We have copies here to help 
+
+## Reviewer letters
+
+### Sample review request letter
+
+Dear Dr. {{AUTHOR-LAST-NAME}},
+
+Please be sure you review and understand our conflict of interest policies before making a decision on whether or not to accept this review request.
+
+Thank you very much.
+{{SENDER-FULL-NAME}},
+Editor, Living Journal of Computational Molecular Science
+
+**Manuscript title, authors, and deadline are included below the email automatically by Scholastica**
+
+**Accept/Decline link is automatically included by Scholastica, along with ability to suggest alternate reviewers.**
+
+### Sample review action/thanks for agreeing letter
+
+(Each category has its own form letter, differing in the link to category-specific review criteria. )
+
+Dear XYZ,
+
+Thank you very much for agreeing to review the LiveCoMS submission, `{{MANUSCRIPT-TITLE}}`.
+Your support of our new community-run journal is very encouraging.
+
+I would appreciate receiving your review within 10 days, by `TTTTTT`.
+
+The article is to be considered under the `YYY` category.
+To aid you in your review, both the general [review criteria](https://livecomsjournal.github.io/authors/policies/#review-criteria) and the criteria specific to [Best Practices Guides](https://livecomsjournal.github.io/authors/best_practices/) are appended below.
+
+Please read our conflict-of-interest criteria and inform me of any potential conflicts.
+
+Note also that non-anonymous feedback can be provided directly to authors via the GitHub page linked in the manuscript, if you so desire.
+
+If you have any questions, please reply to this email.
+
+Thank you very much.
+`{{SENDER-FULL-NAME}}`, Associate Editor
+
+REVIEW CRITERIA
+`Fill in current general review criteria`
+`Fill in current category-specific review criteria`
+
+### Reviewer form
+
+(All fields will be communicated to the authors except comments to the editor)
+- Overall rating (one to five stars, with five being best)
+- For this manuscript I recommend (Accept/Revise and resubmit/Reject)
+- How well does the manuscript meet overall review criteria and category-specific criteria?
+- Is the paper adequately edited for clear scientific English?
+- Given that the accepted PDF will be the final version of the manuscript, are there formatting, style, or quality issues which should be addressed before acceptance? What about the quality of the figures, layout of any tables, etc.?
+- Comments to the editor
+
+
+## Sample decision letters
+
+
+### Minor revisions
+
+Following is a sample decision letter which might be used for communicating the outcome of the review process to the authors.
+
+Dear Dr. `{{AUTHOR-LAST-NAME}}`,
+
+Thank you very much for your submission of your article, `{{MANUSCRIPT-TITLE}}`, to the Living Journal of Computational Molecular Sciences (LiveCOMS).
+We are delighted to inform you that we anticipate being able to accept your article, pending satisfactory completion of minor revisions as recommended by the reviewers (and detailed below).
+To facilitate the re-review of your manuscript, please submit a PDF version with *highlighted* changes, such as via [latexdiff](https://www.sharelatex.com/blog/2013/02/16/using-latexdiff-for-marking-changes-to-tex-documents.html).
+A final unhighlighted, publication-ready version will be requested should your manuscript be accepted.
+As you make the recommended changes, we also encourage you to make a final check that:
+- The article is well edited and all images and tables are of high quality and well laid out
+- Your final submitted PDF is in fact how you want your article to appear in its final version, as the journal does not typeset or alter the formatting of your article
+- Your GitHub repository is in order and ready to accept feedback from readers
+
+Thank you again for joining with us in this exciting new publishing enterprise!
+
+Sincerely,
+`{{SENDER-FULL-NAME}}`
+
+### More significant revisions
+
+(Same letter as the above, but with the following type of language instead)
+
+""...Your manuscript was judged to have significant merit and may ultimately be suitable for publication, but significant revisions are required. Please see the reviewer comments below." [continue with same letter as for minor]
+
+### Rejection
+
+"Unfortunately, we will not be able to accept your manuscript for publication. [editor should insert note here about whether manuscript was outside scope of journal, not of suitable quality, or otherwise inappropriate]..."

--- a/website_text/letter_templates.md
+++ b/website_text/letter_templates.md
@@ -4,12 +4,20 @@ Below of typical form letters used for correspondence with reviewers.  Note that
 
 ### Sample review request letter
 
-Dear Dr. {{AUTHOR-LAST-NAME}},
+Dear Dr. {{AUTHOR-LAST-NAME},  (Change from Dr. if going to a grad student)
 
-Please be sure you review and understand our conflict of interest policies before making a decision on whether or not to accept this review request.
+I would like to invite you to review an article entitled "{{MANUSCRIPT-TITLE}}", which has been submitted to the Living Journal of Computational Molecular Science (LiveCOMS). The abstract of the article is included below.
 
-Thank you very much.
-{{SENDER-FULL-NAME}},
+LiveCoMS is a new and unique journal, which focuses on promoting best practices in molecular computation via updateable educational articles of various kinds - tutorials, reviews, best practices descriptions, comparisons of computational programs, and “lessons learned” about molecular simulation. The journal is low-cost, non-profit and run by members of our community in a transparent way; in part, it aims to provide academic credit for important work that often goes unrewarded. We encourage you to learn more about the journal at the journal web site as well as learn more about the unique aspects of the review process for LiveCOMS.
+
+Reviews are due in 21 days. If you feel you are unable to review this article, we would appreciate suggestions of other reviewers. 
+
+LiveCOMS has a Conflicts of Interest policy and reviewers should make sure they are familiar with this and decline to review if they have a conflict, or if they are uncertain, to disclose any potential conflicts to the editor managing the review process.
+
+If you have any other questions about the reviewing process, please respond to this email, or feel free to reach out to the editors at managing@livecomsjournal.org.
+
+Thank you very much,
+{{SENDER-FULL-NAME}}
 Editor, Living Journal of Computational Molecular Science
 
 **Manuscript title, authors, and deadline are included below the email automatically by Scholastica**
@@ -18,30 +26,7 @@ Editor, Living Journal of Computational Molecular Science
 
 ### Sample review action/thanks for agreeing letter
 
-(Each category has its own form letter, differing in the link to category-specific review criteria. )
-
-Dear XYZ,
-
-Thank you very much for agreeing to review the LiveCoMS submission, `{{MANUSCRIPT-TITLE}}`.
-Your support of our new community-run journal is very encouraging.
-
-I would appreciate receiving your review within 10 days, by `TTTTTT`.
-
-The article is to be considered under the `YYY` category.
-To aid you in your review, both the general [review criteria](https://livecomsjournal.github.io/authors/policies/#review-criteria) and the criteria specific to [Best Practices Guides](https://livecomsjournal.github.io/authors/best_practices/) are appended below.
-
-Please read our conflict-of-interest criteria and inform me of any potential conflicts.
-
-Note also that non-anonymous feedback can be provided directly to authors via the GitHub page linked in the manuscript, if you so desire.
-
-If you have any questions, please reply to this email.
-
-Thank you very much.
-`{{SENDER-FULL-NAME}}`, Associate Editor
-
-REVIEW CRITERIA
-`Fill in current general review criteria`
-`Fill in current category-specific review criteria`
+There is no review action template from Scholastica.  I am asking about this.  We will route information through the reviewer instructions.
 
 ### Reviewer form
 

--- a/website_text/letter_templates.md
+++ b/website_text/letter_templates.md
@@ -10,7 +10,7 @@ I would like to invite you to review an article entitled "{{MANUSCRIPT-TITLE}}",
 
 LiveCoMS is a new and unique journal, which focuses on promoting best practices in molecular computation via updateable educational articles of various kinds - tutorials, reviews, best practices descriptions, comparisons of computational programs, and “lessons learned” about molecular simulation. The journal is low-cost, non-profit and run by members of our community in a transparent way; in part, it aims to provide academic credit for important work that often goes unrewarded. We encourage you to learn more about the journal at the journal web site as well as learn more about the unique aspects of the review process for LiveCOMS.
 
-Reviews are due in 21 days. If you feel you are unable to review this article, we would appreciate suggestions of other reviewers. 
+Reviews are due in 15 days. If you feel you are unable to review this article, we would appreciate suggestions of other reviewers. 
 
 LiveCOMS has a Conflicts of Interest policy and reviewers should make sure they are familiar with this and decline to review if they have a conflict, or if they are uncertain, to disclose any potential conflicts to the editor managing the review process.
 


### PR DESCRIPTION
The reviewer template forms are moved here.  They are removed from the previous repository as part of https://github.com/livecomsjournal/livecomsjournal.github.io/pull/143

The idea is to have them here for discussion, as the actual templates are accessible to the editors at the Scholastica web page.